### PR TITLE
Upgrading jshint to latest version 2.6 with bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "jshint": "^2.5.6",
+    "jshint": "^2.6.0",
     "lodash": "^3.0.1",
     "minimatch": "^2.0.1",
     "rcloader": "0.1.2",


### PR DESCRIPTION
The 2.6 release of jshint was created 16 days ago and has bugfixes that I need relating to ES6. Thank you!